### PR TITLE
Add drush path for Drush 12/Drupal 10.

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -7,6 +7,8 @@ ARG TARGETARCH
 
 COPY --link rootfs /
 
+ENV PATH="/var/www/drupal/vendor/bin:$PATH"
+
 RUN --mount=type=cache,id=custom-drupal-composer-${TARGETARCH},sharing=locked,target=/root/.composer/cache \
     composer install -d /var/www/drupal && \
     chown -R nginx:nginx /var/www/drupal && \


### PR DESCRIPTION
I followed some instructions online to add the path to drush (and other vendored binaries) in the Dockerfile.

Solves https://github.com/Islandora-Devops/isle-site-template/issues/8. 