### PR TITLE
Add support for wildcard certificates

### DIFF
--- a/.env
+++ b/.env
@@ -43,5 +43,12 @@ TAG=local
 # The domain at which your production site is hosted.
 DOMAIN=islandora.dev
 
+# How to separate subdomains (e.g. fcrepo, activemq, solr, etc)
+# from the parent domain
+# valid values are a single character. Either . or -
+# A period (.) is the default value
+# A dash (-) is used if supplying your own wildcard cert for your domain
+SUBDOMAIN_DELIMITER=.
+
 # The email to use for admin users and Lets Encrypt.
 EMAIL=postmaster@example.com

--- a/README.template.md
+++ b/README.template.md
@@ -460,6 +460,16 @@ EMAIL=postmaster@example.com
 
 > N.B. This is required to property generate certificates automatically!
 
+## Using a Wildcard Certificate
+
+If your production Islandora site is using a wildcard certificate that is not provisioned by LetsEncrypt, your DNS entries for your subdomain `DOMAIN` may need to be at the same level as your wildcard's top level domain (TLD).
+
+For example if your wildcard cert is for `*.library.world.com` and your islandora site is at `islandora.library.world.com`, to have your `activemq`, `blazegraph`, `fcrepo`, and `solr` subdomains use the same TLS certificate, they will need to be children of `library.world.com`. To accomplish this, you can change the subdomain delimiter in your `.env` to use a dash (-) instead of a period (.).
+
+```bash
+SUBDOMAIN_DELIMITER=-
+```
+
 ## Setup as a systemd Service
 
 Most Linux distributions use `systemd` for process management, on your production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,7 +228,7 @@ services:
         <<: [*prod, *activemq]
         labels:
             <<: [*traefik-disable, *activemq-labels]
-            traefik.http.routers.activemq_http.rule: &traefik-host-activemq-prod Host(`activemq.${DOMAIN}`)
+            traefik.http.routers.activemq_http.rule: &traefik-host-activemq-prod Host(`activemq${SUBDOMAIN_DELIMITER}${DOMAIN}`)
             traefik.http.routers.activemq_https.rule: *traefik-host-activemq-prod
             traefik.http.routers.activemq_https.tls.certresolver: *traefik-certresolver
         secrets:
@@ -257,7 +257,7 @@ services:
         <<: [*prod, *blazegraph]
         labels:
             <<: [*traefik-disable, *blazegraph-labels]
-            traefik.http.routers.blazegraph_http.rule: &traefik-host-blazegraph-prod Host(`blazegraph.${DOMAIN}`)
+            traefik.http.routers.blazegraph_http.rule: &traefik-host-blazegraph-prod Host(`blazegraph${SUBDOMAIN_DELIMITER}${DOMAIN}`)
             traefik.http.routers.blazegraph_https.rule: *traefik-host-blazegraph-prod
             traefik.http.routers.blazegraph_https.tls.certresolver: *traefik-certresolver
     cantaloupe-dev: &cantaloupe
@@ -354,7 +354,7 @@ services:
             <<: [*drupal-environment]
             DEVELOPMENT_ENVIRONMENT: false
             DRUPAL_DEFAULT_CANTALOUPE_URL: "https://${DOMAIN}/cantaloupe/iiif/2"
-            DRUPAL_DEFAULT_FCREPO_URL: "https://fcrepo.${DOMAIN}/fcrepo/rest/"
+            DRUPAL_DEFAULT_FCREPO_URL: "https://fcrepo${SUBDOMAIN_DELIMITER}${DOMAIN}/fcrepo/rest/"
             DRUPAL_DEFAULT_MATOMO_URL: "https://${DOMAIN}/matomo/"
             DRUPAL_DEFAULT_SITE_URL: "${DOMAIN}"
             DRUPAL_DRUSH_URI: "https://${DOMAIN}"
@@ -500,7 +500,7 @@ services:
             FCREPO_ALLOW_EXTERNAL_DRUPAL: "https://${DOMAIN}/"
         labels:
             <<: [*fcrepo-labels]
-            traefik.http.routers.fcrepo_http.rule: &traefik-host-fcrepo-prod Host(`fcrepo.${DOMAIN}`)
+            traefik.http.routers.fcrepo_http.rule: &traefik-host-fcrepo-prod Host(`fcrepo${SUBDOMAIN_DELIMITER}${DOMAIN}`)
             traefik.http.routers.fcrepo_https.rule: *traefik-host-fcrepo-prod
             traefik.http.routers.fcrepo_https.tls.certresolver: *traefik-certresolver
         secrets:
@@ -584,7 +584,7 @@ services:
         <<: [*prod, *solr]
         labels:
             <<: [*traefik-disable, *solr-labels]
-            traefik.http.routers.solr_http.rule: &traefik-host-solr-prod Host(`solr.${DOMAIN}`)
+            traefik.http.routers.solr_http.rule: &traefik-host-solr-prod Host(`solr${SUBDOMAIN_DELIMITER}${DOMAIN}`)
             traefik.http.routers.solr_https.rule: *traefik-host-solr-prod
             traefik.http.routers.solr_https.tls.certresolver: *traefik-certresolver
         # Ensure drupal mounts the shared volumes first.
@@ -677,10 +677,10 @@ services:
                 aliases:
                     # Allow services to connect on the same name/port as the outside.
                     - "${DOMAIN}" # Drupal is at the root domain.
-                    - "activemq.${DOMAIN}"
-                    - "blazegraph.${DOMAIN}"
-                    - "fcrepo.${DOMAIN}"
-                    - "solr.${DOMAIN}"
+                    - "activemq${SUBDOMAIN_DELIMITER}${DOMAIN}"
+                    - "blazegraph${SUBDOMAIN_DELIMITER}${DOMAIN}"
+                    - "fcrepo${SUBDOMAIN_DELIMITER}${DOMAIN}"
+                    - "solr${SUBDOMAIN_DELIMITER}${DOMAIN}"
         depends_on:
             # Sometimes traefik doesn't pick up on new containers so make sure
             # they are started before traefik.


### PR DESCRIPTION
For sites that might utilize a wildcard TLS certificate, having the fcrepo/activemq/etc. domains be children of the drupal domain will not allow the same wildcard certificate to be used. This PR makes those subdomains the same level as the drupal domain, while keeping the default the way it was before.

Would be ideal if `-` could simply replace `.` as the subdomain delimiter, but opted to send this PR to support both in case `.` is a hard requirement for some use cases.