### PR TITLE
Specify fcrepo version in docker-compose.yml

### DIFF
--- a/.env
+++ b/.env
@@ -45,3 +45,6 @@ DOMAIN=islandora.dev
 
 # The email to use for admin users and Lets Encrypt.
 EMAIL=postmaster@example.com
+
+# Whether using fcrepo version 6
+FEDORA_6=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,8 @@ services:
             default:
                 aliases: # Allow access without using the `-dev` or `-prod` suffix.
                     - milliner
+        environment:
+            MILLINER_FEDORA6: ${FEDORA_6}
     milliner-prod:
         <<: [*prod, *milliner]
         secrets: *secrets-jwt-public


### PR DESCRIPTION
Without this environment variable set, the milliner container runs logic used against fcrepo v5, but `isle-site-template` ships with fcrepo 6. Without this environment variable passed to the milliner container, some crayfish derivative services fail in unexpected ways.

Relevant code that sets/references this env var:

- [Default value set here](https://github.com/Islandora-Devops/isle-buildkit/blob/511513eaba9f5b9d130886442710d29d46b502eb/milliner/Dockerfile#L18)
- [Environment value referenced here](https://github.com/Islandora/Crayfish/blob/fd2b04c6ec6c4a4145b7df8f600bc0fb9fda6c18/Milliner/config/services.yaml#L32) and [here](https://github.com/Islandora-Devops/isle-buildkit/blob/511513eaba9f5b9d130886442710d29d46b502eb/milliner/rootfs/etc/confd/templates/services.yaml.tmpl#L10)