### PR TITLE
Default to use MySQL persistence instead of File persistence for Fedora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -469,6 +469,7 @@ services:
         environment: &fcrepo-environment
             FCREPO_ALLOW_EXTERNAL_DEFAULT: "http://default/"
             FCREPO_ALLOW_EXTERNAL_DRUPAL: "https://islandora.dev/"
+            FCREPO_PERSISTENCE_TYPE: "mysql"
         labels: &fcrepo-labels
             <<: [*traefik-enable, *traefik-https-redirect-middleware]
             # Due to weird logic in `fcrepo/static/js/common.js`, do not use https

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -470,6 +470,8 @@ services:
             FCREPO_ALLOW_EXTERNAL_DEFAULT: "http://default/"
             FCREPO_ALLOW_EXTERNAL_DRUPAL: "https://islandora.dev/"
             FCREPO_PERSISTENCE_TYPE: "mysql"
+            DB_HOST: mariadb
+            DB_PORT: 3306
         labels: &fcrepo-labels
             <<: [*traefik-enable, *traefik-https-redirect-middleware]
             # Due to weird logic in `fcrepo/static/js/common.js`, do not use https


### PR DESCRIPTION
Provide the necessary environment variables to create a database for fedora.

- [FCREPO_PERSISTENCE_TYPE](https://github.com/Islandora-Devops/isle-buildkit/tree/main/fcrepo6#confd-settings) is defined in the fcrepo docker image. This configured fedora to use mysql as the persistant storage and is the recommended setting for production systems: https://wiki.lyrasis.org/display/FEDORA6x/Database+Cache
- `DB_HOST` and `DB_PORT` are inherited [from the base image](https://github.com/Islandora-Devops/isle-buildkit/blob/main/base/README.md#database-settings), and [have no default value](https://github.com/Islandora-Devops/isle-buildkit/blob/main/base/Dockerfile#L112) in the fcrepo container. Those values are needed by [the script that creates the database](https://github.com/Islandora-Devops/isle-buildkit/blob/20ce60742bf65341613d3c867fc505cbeb328efa/base/rootfs/usr/local/bin/create-database.sh#L131-L136).

Related to https://github.com/Islandora-Devops/isle-site-template/issues/21