### PR TITLE
Trust local, dev CA in containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,9 +147,15 @@ services:
         depends_on:
             activemq-prod:
                 condition: service_started
-    crayfits:
-        <<: [*common]
+    crayfits-dev: &crayfits
+        <<: [*dev, *common]
         image: ${ISLANDORA_REPOSITORY}/crayfits:${ISLANDORA_TAG}
+        networks:
+            default:
+                aliases: # Allow access without using the `-dev` or `-prod` suffix.
+                    - crayfits
+    crayfits-prod:
+        <<: [*prod, *crayfits]
     fits:
         <<: [*common]
         image: ${ISLANDORA_REPOSITORY}/fits:${ISLANDORA_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ x-dev: &dev
         - source: CERT_PRIVATE_KEY
         - source: CERT_AUTHORITY
         - source: UID
+    volumes:
+        - ./certs/rootCA.pem:/usr/local/share/ca-certificates/cert.pem
 
 # Will override what is in x-dev, x-common.
 x-prod: &prod


### PR DESCRIPTION
For the dev profile, a locally trusted CA is created and used to serve TLS traffic on https://islandora.dev.

This locally signed CA is not trusted by containers, only by the host operating system.

[isle-buildkit already updates the proper CA trust store in the base s6 overlay](https://github.com/Islandora-Devops/isle-buildkit/blob/6efb7cd22b60d818624b301954c584af64ae9233/base/rootfs/etc/s6-overlay/scripts/cacert-import.sh#L7). We can use this to trust the local CA inside other containers.

## Testing

Create a site using the `isle-site-template` and start the dev profile

```
docker compose --profile dev up -d
```

Add media to your site, and see that no derivates are created.

Use this PR's YML and bring down your containers and backup and see the derivates are created

```
docker compose stop
docker compose --profile dev stop
docker compose --profile dev up -d
```
