### PR TITLE
add restart unless-stopped to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 
 # Common to all services
 x-common: &common
-    restart: "no"
+    restart: unless-stopped
     tty: true # Required for non-root users with selinux enabled.
     security_opt:
         - label=type:container_runtime_t # Required for selinux to access the docker socket and bind mount files.


### PR DESCRIPTION
changed from `restart: "no"` to `restart: unless-stopped` so containers will restart if server or docker is restarted

This is the behaviour we had in isle-dc and likely what everyone would want to use in production environments. Without this, sites will not spin back up if the server hosting them restarts or if Docker restarts