### PR TITLE
remove profile prod from pull instructions

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -92,7 +92,7 @@ The Docker Compose file provided requires that you pull the non-buildable island
 images with the following command:
 
 ```bash
-docker compose --profile dev --profile prod pull --ignore-buildable --ignore-pull-failures
+docker compose --profile dev pull --ignore-buildable --ignore-pull-failures
 ```
 
 ## Running / Stoping / Destroying


### PR DESCRIPTION
Pulling dev and prod images has been causing some confusion, and in at least one instance it caused someone to be unable to pull the images.

The only difference seems to be that the dev profile pulls the IDE image, since otherwise the images are the same between dev and prod, so this should still pull the same set of images.