### PR TITLE
Run Tag based migrations so that we get Mirador term and there's less reason to fork site template.

### DIFF
--- a/drupal/rootfs/etc/s6-overlay/scripts/install.sh
+++ b/drupal/rootfs/etc/s6-overlay/scripts/install.sh
@@ -12,7 +12,7 @@ function configure {
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" user:role:add fedoraadmin admin
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" pm:uninstall pgsql sqlite
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" migrate:import --userid=1 islandora_tags,islandora_defaults_tags,islandora_fits_tags
+    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" migrate:import --userid=1 --tag=islandora
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cron || true
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" search-api:index || true
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild


### PR DESCRIPTION
We used to run islandora migrations as a "group" but (to simplify greatly) Drupal stopped supporting migration groups. What we should be using now are tags. Most islandora migrations are tagged with "islandora".

However at some point, we made the (IMO, wrong) choice to not use tags in the site template but to name the migrations that we wanted to run.

This prevents other modules - like islandora mirador - from creating migrations that need to get run during provisioning. 

This PR makes the Site Template on par with ISLE-DC by running the migrations with `--tag=islandora`. In practice, this means you'll get the Mirador term in the "Islandora Display" vocabulary.

It would be good to make more people aware that "we run migrations tagged with `islandora` on provisioning` to empower people to do what they want to without having to fork our provisioning systems.

