### PR TITLE
Add lint and basic test

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,47 @@
+name: lint-test
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: shellcheck *.sh
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: drupal/Dockerfile
+          verbose: true
+
+  test:
+    needs: [lint]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install mkcert (windows)
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: Invoke-WebRequest -Uri "https://dl.filippo.io/mkcert/latest?for=windows/amd64" -OutFile "C:\Windows\System32\mkcert.exe"
+
+      - name: install mkcert (ubuntu or macos)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |-
+          ARCH="linux/amd64"
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            ARCH="darwin/arm64"
+          fi
+
+          curl -JLO "https://dl.filippo.io/mkcert/latest?for=$ARCH"
+          chmod +x mkcert-v*
+          cp mkcert-v* /usr/local/bin/mkcert
+
+      - name: generate-certs
+        shell: bash
+        run: ./generate-certs.sh
+
+      - name: generate-secrets
+        shell: bash
+        run: ./generate-secrets.sh

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -5,7 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - run: shellcheck *.sh
+
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: drupal/Dockerfile
@@ -16,22 +18,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
 
-      - name: install mkcert (windows)
-        if: matrix.os == 'windows-latest'
-        shell: powershell
-        run: Invoke-WebRequest -Uri "https://dl.filippo.io/mkcert/latest?for=windows/amd64" -OutFile "C:\Windows\System32\mkcert.exe"
-
       - name: install mkcert (ubuntu or macos)
-        if: matrix.os != 'windows-latest'
         shell: bash
         run: |-
           ARCH="linux/amd64"
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             ARCH="darwin/arm64"
+          elif [ "${{ matrix.os }}" = "macos-13" ]; then
+            ARCH="darwin/amd64"
           fi
 
           curl -JLO "https://dl.filippo.io/mkcert/latest?for=$ARCH"

--- a/generate-secrets.sh
+++ b/generate-secrets.sh
@@ -6,6 +6,7 @@
 set -euf -o pipefail
 
 PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROGDIR="."
 readonly PROGDIR
 
 # Get the tag for the base image.

--- a/generate-secrets.sh
+++ b/generate-secrets.sh
@@ -6,7 +6,6 @@
 set -euf -o pipefail
 
 PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROGDIR="."
 readonly PROGDIR
 
 # Get the tag for the base image.


### PR DESCRIPTION
I'm getting some CI/CD integration tests going with this repo as a dependency. When running `./generate-secrets.sh` was seeing some grep errors

```
grep: write error: Broken pipe
```

But that stderr message ended up just being an error that was printed but the command succeeded successfully, so the scripts in this repo are working well 👍 

All that said, in doing all this debugging did add some GitHub Actions CI for lint/test we may want to consider in this repo?