### PR TITLE
Update TAG in .env

### DIFF
--- a/.env
+++ b/.env
@@ -30,8 +30,7 @@ CONSISTENCY=delegated
 ISLANDORA_REPOSITORY=islandora
 
 # The version of the isle-buildkit images to use.
-# @todo change this to 2.0.0 when ready.
-ISLANDORA_TAG=main
+ISLANDORA_TAG=3.2.4
 
 # The Docker image repository, to push/pull custom images from.
 # islandora.io redirects to localhost.


### PR DESCRIPTION
Initial comment said to change TAG to 2.0.0 when ready. We're now into 3.x so the comment was removed and the most recent buildkit release is now specified.