### PR TITLE
Support reverse proxies

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,34 @@
+name: Run tests
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      buildkit-tag:
+        description: "The isle-buildkit tag to pull for the fleet of docker containers"
+        required: true
+        type: string
+        default: 'main'
+      starter-site-ref:
+        description: "The islandora-starter-site ref to checkout (heads/BRANCH-NAME or tags/TAG-NAME)"
+        required: true
+        type: string
+        default: 'heads/main'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ISLANDORA_TAG: "${{ github.event.inputs.buildkit-tag }}"
+      ISLANDORA_STARTER_REF: "${{ github.event.inputs.starter-site-ref }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: shellcheck tests/*.sh
+
+      - name: install mkcert
+        run: |-
+          curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+          chmod +x mkcert-v*-linux-amd64
+          sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+
+      - name: start islandora-starter-site
+        run: ./tests/init-template-starter.sh

--- a/setup.sh
+++ b/setup.sh
@@ -102,7 +102,7 @@ function initialize_from_site_template {
   echo "Initializing from site template..."
   ref=$(choose_ref "${repo}")
   curl -L "${repo}/archive/${ref}.tar.gz" | tar -xz --strip-components=1
-  rm -fr .github setup.sh
+  rm -fr .github setup.sh tests
   git add .
   git commit -am "First commit, added isle-site-template."
 }

--- a/tests/init-template-starter.sh
+++ b/tests/init-template-starter.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+if [ ! -v ISLANDORA_STARTER_REF ] || [ "$ISLANDORA_STARTER_REF" = "" ]; then
+  ISLANDORA_STARTER_REF=heads/main
+fi
+
+if [ ! -v ISLANDORA_TAG ] || [ "$ISLANDORA_TAG" = "" ]; then
+  ISLANDORA_TAG=main
+fi
+
+mv drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt .
+
+curl -L "https://github.com/Islandora-Devops/islandora-starter-site/archive/refs/${ISLANDORA_STARTER_REF}.tar.gz" \
+  | tar --strip-components=1 -C drupal/rootfs/var/www/drupal -xz
+
+mv default_settings.txt drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt
+
+./generate-certs.sh
+./generate-secrets.sh
+
+docker compose --profile dev up -d
+
+./tests/ping.sh

--- a/tests/ping.sh
+++ b/tests/ping.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+COUNTER=0
+while true; do
+  HTTP_STATUS=$(curl -w '%{http_code}' -o /dev/null -s https://islandora.dev/)
+  echo "Ping returned http status ${HTTP_STATUS}, exit code $?"
+  if [ "${HTTP_STATUS}" -eq 200 ]; then
+    echo "We're live 🚀"
+    exit 0
+  fi
+
+  ((COUNTER++))
+  if [ "${COUNTER}" -eq 50 ]; then
+    echo "Failed to come online after 4m"
+    exit 1
+  fi
+  sleep 5;
+done


### PR DESCRIPTION
First, adding adding an integration test to make sure we don't introduce any regressions.

Then will see if we can tweak `.env` and `docker-compose.yml` to allow this docker compose deployment to be a backend to some other frontend domain that acts as a reverse proxy