### PR TITLE
replaced wget with cURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See the [customizations](#customizations) steps afterwards about removing unwant
 - [Docker 24.0+](https://docs.docker.com/get-docker/) **Referring to the Docker Engine version, not Docker Desktop**.
 - [Docker Compose](https://docs.docker.com/compose/install/linux/) **Already included in OSX with Docker**
 - [mkcert 1.4+](https://github.com/FiloSottile/mkcert)
-- `wget` and `git`
+- `cURL` and `git`
 ## Java and macOS
 
 mkcert seems to have problems when running on Java installed via Homebrew. 

--- a/README.template.md
+++ b/README.template.md
@@ -46,7 +46,7 @@ This is the development and production infrastructure for INSTITUTION's SITE_NAM
 - [Docker 24.0+](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/linux/) **Already included in OSX with Docker**
 - [mkcert 1.4+](https://github.com/FiloSottile/mkcert) **Local Development only**
-- `wget` and `git`
+- `cURL` and `git`
 
 # Docker Compose
 

--- a/setup.sh
+++ b/setup.sh
@@ -112,9 +112,8 @@ function initialize_from_starter_site {
   local ref
   echo "Initializing from starter site..."
   ref=$(choose_ref "${repo}")
-  wget \
-    -c "${repo}/archive/${ref}.tar.gz" \
-    -O - | tar --strip-components=1 -C drupal/rootfs/var/www/drupal -xz
+  curl -L "${repo}/archive/${ref}.tar.gz" \
+    | tar --strip-components=1 -C drupal/rootfs/var/www/drupal -xz
   rm -fr drupal/rootfs/var/www/drupal/.github
   git checkout drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt
   git add .


### PR DESCRIPTION
Replaced call to wget in setup.sh with cURL which is installed by default on OSX. The cURL call was already being used in the manual instructions.

Also updated the requirements to include cURL instead of wget