### PR TITLE
Update README.md to mention ISLANDORA_TAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ name. If you have multiple sites on the same host, these must be unique.
 COMPOSE_PROJECT_NAME=isle-site-template
 ```
 
+ISLANDORA_TAG tells Docker what version of [Isle Buildkit](https://github.com/Islandora-Devops/isle-buildkit) 
+to use for the images. You should set this to the most 
+[recent release](https://github.com/Islandora-Devops/isle-buildkit/releases) number, 
+unless you have a reason to use older images.
+
+> Note: You should not use `ISLANDORA_TAG=main` in production.
+
 If setting up your own images on a remote Docker image registry like [DockerHub],
 set the following line to your use your image registry:
 


### PR DESCRIPTION
Per our conversation in the tech call about keeping ISLANDORA_TAG up to date, this adds mention of using the latest TAG when initially installing. 

If this is merged, it should be less important to keep the ISLANDORA_TAG up to date with buildkit, but we also discussed possibly automating that process, or setting it to main, with the assumption that the user will change it.