### PR TITLE
Remove obsolete docker compose version

### DIFF
--- a/docker-compose.darwin.yml
+++ b/docker-compose.darwin.yml
@@ -2,7 +2,6 @@
 # authenticate against Github / use the Jetbrains for local development.
 # Platform specific for use on OSX.
 ---
-version: "3.8"
 services:
   ide:
     environment:

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -2,7 +2,6 @@
 # authenticate against Github / use the Jetbrains for local development.
 # Platform specific for use on Linux hosts, and WSL.
 ---
-version: "3.8"
 services:
   ide:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 # Common to all services
 x-common: &common
     restart: unless-stopped


### PR DESCRIPTION
Including the version number in the docker compose yaml files displays the message docker compose version is obsolete. Docker compose v2 will always use the latest version of the compose file scheme and it no longer requires the version number.