### PR TITLE
Update ping.sh to succeed on 302

### DIFF
--- a/tests/ping.sh
+++ b/tests/ping.sh
@@ -4,7 +4,7 @@ COUNTER=0
 while true; do
   HTTP_STATUS=$(curl -w '%{http_code}' -o /dev/null -s https://islandora.dev/)
   echo "Ping returned http status ${HTTP_STATUS}, exit code $?"
-  if [ "${HTTP_STATUS}" -eq 200 ]; then
+  if [ "${HTTP_STATUS}" -eq 200 ] || [ "${HTTP_STATUS}" -eq 302 ]; then
     echo "We're live 🚀"
     exit 0
   fi


### PR DESCRIPTION
Tests keep failing because pinging the site is returning 302 instead of 200. This should allow the tests to succeed in that case.