### PR TITLE
Add traefik readTimeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -562,7 +562,6 @@ services:
             --api.debug=true
             --entryPoints.http.address=:80
             --entryPoints.https.address=:443
-            # see https://doc.traefik.io/traefik/routing/entrypoints/#respondingtimeouts
             --entryPoints.https.transport.respondingTimeouts.readTimeout=60
             --entryPoints.ssh.address=:22
             --providers.file.filename=/etc/traefik/tls.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -562,6 +562,8 @@ services:
             --api.debug=true
             --entryPoints.http.address=:80
             --entryPoints.https.address=:443
+            # see https://doc.traefik.io/traefik/routing/entrypoints/#respondingtimeouts
+            --entryPoints.https.transport.respondingTimeouts.readTimeout=60
             --entryPoints.ssh.address=:22
             --providers.file.filename=/etc/traefik/tls.yml
             --providers.docker=true


### PR DESCRIPTION
Closes https://github.com/Islandora-Devops/isle-site-template/issues/67

## TODO

Should we make this an env variable for a timeout nginx/drupal also uses to keep things somewhat consistent since troubleshooting timeout settings can be difficult?