### PR TITLE
Add additional env vars for drupal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -320,6 +320,9 @@ services:
             DRUPAL_DEFAULT_PROFILE: "minimal"
             DRUPAL_DEFAULT_SITE_URL: "islandora.dev"
             DRUPAL_DEFAULT_SOLR_CORE: "default"
+            DRUPAL_DEFAULT_DB_DRIVER: "mysql"
+            DRUPAL_DEFAULT_DB_HOST: "mariadb"
+            DRUPAL_DEFAULT_DB_PORT: 3306
             DRUPAL_DRUSH_URI: "https://islandora.dev" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
         volumes:
             # Allow code-server to serve Drupal / override it.

--- a/tests/ping.sh
+++ b/tests/ping.sh
@@ -12,6 +12,7 @@ while true; do
   ((COUNTER++))
   if [ "${COUNTER}" -eq 50 ]; then
     echo "Failed to come online after 4m"
+    docker logs isle-site-template-drupal-dev-1
     exit 1
   fi
   sleep 5;


### PR DESCRIPTION
Without this, `install_default` was failing on new site installs with

```
$ source /etc/islandora/utilities.sh
$ install_site default
--driver
--host
--port
--dbuser drupal_default
--dbname drupal_default
PROFILE: minimal
--account-mail=webmaster@localhost.com
--account-name=admin
--site-mail=webmaster@localhost.com
--locale=en
--site-name=Islandora Digital Collections
--sites-subdir=default
USE_EXISTIG_CONFIG: --existing-config
EVERYTHING ELSE:
Missing one of required options: --host --port --db-user --db-password --db-name
```

May be best fixed at the image: https://github.com/Islandora-Devops/isle-buildkit/pull/351 