### PR TITLE
Fix for failing integration tests.

### DIFF
--- a/drupal/rootfs/etc/s6-overlay/scripts/install.sh
+++ b/drupal/rootfs/etc/s6-overlay/scripts/install.sh
@@ -8,6 +8,11 @@ source /etc/islandora/utilities.sh
 readonly SITE="default"
 
 function configure {
+    # Work around for when the cache is in a bad state, as Drush will access
+    # the cache before rebuilding it for some dumb reason, preventing
+    # Drush from being able to clear it.
+    local params=$(/var/www/drupal/web/core/scripts/rebuild_token_calculator.sh 2>/dev/null)
+    curl -L "${DRUPAL_DRUSH_URI}/core/rebuild.php?${params}"
     # Starter site post install steps.
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
     drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" user:role:add fedoraadmin admin

--- a/tests/init-template-starter.sh
+++ b/tests/init-template-starter.sh
@@ -25,6 +25,9 @@ cp ./tests/solr.php drupal/rootfs/var/www/drupal/
 
 docker compose --profile dev up -d
 
+echo "Waiting for installation..."
+docker compose  --profile dev exec drupal-dev timeout 600 bash -c "while ! test -f /installed; do sleep 5; done"
+
 ./tests/ping.sh
 
 docker compose --profile dev exec drupal-dev drush scr solr.php


### PR DESCRIPTION
I was able to debug this, thanks to the SQL dump provided by @joecorall on https://github.com/Islandora-Devops/isle-site-template/pull/71. 

Though, this is just a patch over the problem to account for `drush`'s behaviour. The site seems to install correctly regardless, but afterwards the cache is in a bad state, but only occasionally. Why, I do not know. I've not been able to catch it in the act. Though not relying on `drush` but rather `drupal` to do the initial rebuild seems to deal with the problem (for a stretched definition of deal). Something about `drush install` is not deterministic, or at the very least, is negatively impacted by access to resources or something of the like. 