### PR TITLE
Enhancements to locally running CI tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
+        os: [ubuntu-22.04, ubuntu-24.04]
     env:
       ISLANDORA_TAG: "${{ github.event.inputs.buildkit-tag }}"
       ISLANDORA_STARTER_OWNER: "${{ github.event.inputs.starter-site-owner }}"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,8 +8,13 @@ on:
         required: true
         type: string
         default: 'main'
+      starter-site-owner:
+        description: "The GitHub org the starter site resides in"
+        required: true
+        type: string
+        default: 'Islandora-Devops'
       starter-site-ref:
-        description: "The islandora-starter-site ref to checkout (heads/BRANCH-NAME or tags/TAG-NAME)"
+        description: "The islandora-starter-site git ref to checkout (heads/BRANCH-NAME or tags/TAG-NAME)"
         required: true
         type: string
         default: 'heads/main'
@@ -20,9 +25,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
     env:
       ISLANDORA_TAG: "${{ github.event.inputs.buildkit-tag }}"
+      ISLANDORA_STARTER_OWNER: "${{ github.event.inputs.starter-site-owner }}"
       ISLANDORA_STARTER_REF: "${{ github.event.inputs.starter-site-ref }}"
     steps:
       - uses: actions/checkout@v4

--- a/tests/init-template-starter.sh
+++ b/tests/init-template-starter.sh
@@ -6,6 +6,10 @@ if [ ! -v ISLANDORA_STARTER_REF ] || [ "$ISLANDORA_STARTER_REF" = "" ]; then
   ISLANDORA_STARTER_REF=heads/main
 fi
 
+if [ ! -v ISLANDORA_STARTER_OWNER ] || [ "$ISLANDORA_STARTER_OWNER" = "" ]; then
+  ISLANDORA_STARTER_OWNER="islandora-devops"
+fi
+
 if [ ! -v ISLANDORA_TAG ] || [ "$ISLANDORA_TAG" = "" ]; then
   ISLANDORA_TAG=main
 fi
@@ -13,7 +17,7 @@ fi
 # save the site template default settings.php
 # so we can overwrite it for the starter site
 mv drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt .
-curl -L "https://github.com/Islandora-Devops/islandora-starter-site/archive/refs/${ISLANDORA_STARTER_REF}.tar.gz" \
+curl -L "https://github.com/${ISLANDORA_STARTER_OWNER}/islandora-starter-site/archive/refs/${ISLANDORA_STARTER_REF}.tar.gz" \
   | tar --strip-components=1 -C drupal/rootfs/var/www/drupal -xz
 mv default_settings.txt drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt
 

--- a/tests/ping.sh
+++ b/tests/ping.sh
@@ -4,7 +4,7 @@ COUNTER=0
 while true; do
   HTTP_STATUS=$(curl -w '%{http_code}' -o /dev/null -s https://islandora.dev/)
   echo "Ping returned http status ${HTTP_STATUS}, exit code $?"
-  if [ "${HTTP_STATUS}" -eq 200 ] || [ "${HTTP_STATUS}" -eq 302 ]; then
+  if [ "${HTTP_STATUS}" -eq 200 ]; then
     echo "We're live 🚀"
     exit 0
   fi


### PR DESCRIPTION
I was testing out a starter site PR https://github.com/Islandora-Devops/islandora-starter-site/pull/171 and was running into some issues locally I thought might be good to test for in CI, so made this PR adding `macos-latest` to the OS matrix. But then remembered GitHub can't ship docker in its mac runners because of licensing issues. But this PR still has some utility

- Do not pass tests on 302. A 302 means the site failed to install and is being redirected to the drupal core install screen
- Allow setting what GitHub org the starter site resides in to easily test starter site PRs locally