### PR TITLE
Utilize health checks in service dependencies

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -70,3 +70,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+      - name: cleanup
+        if: ${{ always() }}
+        run: docker compose --profile dev down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,14 +130,14 @@ services:
                     - alpaca
         depends_on:
             activemq-dev:
-                condition: service_started
+                condition: service_healthy
     alpaca-prod:
         <<: [*prod, *alpaca]
         secrets:
             - source: ALPACA_JMS_PASSWORD
         depends_on:
             activemq-prod:
-                condition: service_started
+                condition: service_healthy
     crayfits-dev: &crayfits
         <<: [*dev, *common]
         image: ${ISLANDORA_REPOSITORY}/crayfits:${ISLANDORA_TAG}
@@ -499,7 +499,7 @@ services:
                     - fcrepo
         depends_on:
             activemq-dev:
-                condition: service_started
+                condition: service_healthy
     fcrepo-prod:
         <<: [*prod, *fcrepo]
         environment:
@@ -517,7 +517,7 @@ services:
             - source: JWT_PUBLIC_KEY
         depends_on:
             activemq-prod:
-                condition: service_started
+                condition: service_healthy
     solr-dev: &solr
         <<: [*dev, *common]
         image: ${ISLANDORA_REPOSITORY}/solr:${ISLANDORA_TAG}
@@ -545,14 +545,16 @@ services:
                     - solr
         # Ensure drupal mounts the shared volumes first.
         depends_on:
-            - drupal-dev
+            drupal-dev:
+                condition: service_healthy
     solr-prod:
         <<: [*prod, *solr]
         labels:
             <<: [*traefik-disable, *solr-labels]
         # Ensure drupal mounts the shared volumes first.
         depends_on:
-            - drupal-prod
+            drupal-prod:
+                condition: service_healthy
     traefik-dev: &traefik
         <<: [*dev, *common]
         image: traefik:v3.1.0
@@ -560,6 +562,7 @@ services:
             --api.insecure=true
             --api.dashboard=true
             --api.debug=true
+            --ping=true
             --entryPoints.http.address=:80
             --entryPoints.https.address=:443
             --entryPoints.https.transport.respondingTimeouts.readTimeout=60
@@ -588,6 +591,8 @@ services:
             - ./certs:/etc/ssl/traefik:Z,ro
             - ./dev-tls.yml:/etc/traefik/tls.yml:Z,ro
             - /var/run/docker.sock:/var/run/docker.sock:z
+        healthcheck:
+            test: traefik healthcheck --ping
         networks:
             default:
                 aliases:
@@ -601,12 +606,18 @@ services:
         depends_on:
             # Sometimes traefik doesn't pick up on new containers so make sure
             # they are started before traefik.
-            - activemq-dev
-            - blazegraph-dev
-            - drupal-dev
-            - fcrepo-dev
-            - solr-dev
-            - ide
+            activemq-dev:
+                condition: service_healthy
+            blazegraph-dev:
+                condition: service_started
+            drupal-dev:
+                condition: service_healthy
+            fcrepo-dev:
+                condition: service_healthy
+            solr-dev:
+                condition: service_healthy
+            ide:
+                condition: service_healthy
     traefik-prod:
         <<: [*prod, *traefik]
         # Change caServer to use the staging server when testing changes to the Traefik.
@@ -620,6 +631,7 @@ services:
             --api.insecure=false
             --api.dashboard=false
             --api.debug=false
+            --ping=true
             --entryPoints.http.address=:80
             --entryPoints.https.address=:443
             --entryPoints.http.forwardedHeaders.trustedIPs=${FRONTEND_IP_1},${FRONTEND_IP_2},${FRONTEND_IP_3}
@@ -649,5 +661,7 @@ services:
         depends_on:
             # Sometimes traefik doesn't pick up on new containers so make sure
             # they are started before traefik.
-            - drupal-prod
-            - fcrepo-prod
+            drupal-prod:
+                condition: service_healthy
+            fcrepo-prod:
+                condition: service_healthy

--- a/tests/init-template-starter.sh
+++ b/tests/init-template-starter.sh
@@ -2,16 +2,15 @@
 
 set -eou pipefail
 
-if [ ! -v ISLANDORA_STARTER_REF ] || [ "$ISLANDORA_STARTER_REF" = "" ]; then
-  ISLANDORA_STARTER_REF=heads/main
-fi
+ISLANDORA_STARTER_REF="${ISLANDORA_STARTER_REF:=heads/main}"
+ISLANDORA_STARTER_OWNER="${ISLANDORA_STARTER_OWNER:=islandora-devops}"
+ISLANDORA_TAG="${ISLANDORA_TAG:=main}"
 
-if [ ! -v ISLANDORA_STARTER_OWNER ] || [ "$ISLANDORA_STARTER_OWNER" = "" ]; then
-  ISLANDORA_STARTER_OWNER="islandora-devops"
-fi
-
-if [ ! -v ISLANDORA_TAG ] || [ "$ISLANDORA_TAG" = "" ]; then
-  ISLANDORA_TAG=main
+# allow passing "destroy" to this script to cleanup past runs locally
+if [ $# -eq 1 ] && [ "$1" = "destroy" ]; then
+  rm -rf drupal
+  git checkout -- drupal
+  docker compose --profile dev down --volumes
 fi
 
 # save the site template default settings.php
@@ -28,11 +27,14 @@ cp ./tests/solr.php drupal/rootfs/var/www/drupal/
 ./generate-secrets.sh
 
 docker compose --profile dev build --pull
+docker compose --profile dev pull || echo "continuing"
 docker compose --profile dev up -d
 
 echo "Waiting for installation..."
-docker compose  --profile dev exec drupal-dev timeout 600 bash -c "while ! test -f /installed; do sleep 5; done"
+docker compose --profile dev exec drupal-dev timeout 600 bash -c "while ! test -f /installed; do sleep 5; done"
 
 ./tests/ping.sh
 
 docker compose --profile dev exec drupal-dev drush scr solr.php
+
+docker compose --profile dev down

--- a/tests/init-template-starter.sh
+++ b/tests/init-template-starter.sh
@@ -5,6 +5,7 @@ set -eou pipefail
 ISLANDORA_STARTER_REF="${ISLANDORA_STARTER_REF:=heads/main}"
 ISLANDORA_STARTER_OWNER="${ISLANDORA_STARTER_OWNER:=islandora-devops}"
 ISLANDORA_TAG="${ISLANDORA_TAG:=main}"
+GITHUB_ACTIONS="${GITHUB_ACTIONS:=false}"
 
 # allow passing "destroy" to this script to cleanup past runs locally
 if [ $# -eq 1 ] && [ "$1" = "destroy" ]; then
@@ -37,4 +38,6 @@ docker compose --profile dev exec drupal-dev timeout 600 bash -c "while ! test -
 
 docker compose --profile dev exec drupal-dev drush scr solr.php
 
-docker compose --profile dev down
+if [ "$GITHUB_ACTIONS" = "false" ]; then
+  docker compose --profile dev down
+fi


### PR DESCRIPTION
Now that we have healthchecks in our docker containers (https://github.com/Islandora-Devops/isle-buildkit/pull/370), take advantage of those in the service dependencies.

Also, add a healthcheck to traefik.

And fixed up the CI tests to make it easier to run (and work on mac when the env vars aren't set)