### PR TITLE
fix labels for drupal containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,8 +319,8 @@ services:
             DRUPAL_DRUSH_URI: "https://islandora.dev" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
         labels:
             <<: [*traefik-enable, *traefik-https-redirect-middleware, *traefik-drupal-labels]
-            traefik.http.routers.drupal_http.rule: &traefik-host-drupal-prod Host(`${DOMAIN}`)
-            traefik.http.routers.drupal_https.rule: *traefik-host-drupal-prod
+            traefik.http.routers.drupal_http.rule: &traefik-host-drupal-dev Host(`islandora.dev`)
+            traefik.http.routers.drupal_https.rule: *traefik-host-drupal-dev
             traefik.http.routers.drupal_https.tls.certresolver: *traefik-certresolver
         volumes:
             - &drupal-public-files
@@ -357,6 +357,11 @@ services:
             NGINX_SET_REAL_IP_FROM: ${FRONTEND_IP_1}
             NGINX_SET_REAL_IP_FROM2: ${FRONTEND_IP_2}
             NGINX_SET_REAL_IP_FROM3: ${FRONTEND_IP_3}
+        labels:
+            <<: [*traefik-enable, *traefik-https-redirect-middleware, *traefik-drupal-labels]
+            traefik.http.routers.drupal_http.rule: &traefik-host-drupal-prod Host(`${DOMAIN}`)
+            traefik.http.routers.drupal_https.rule: *traefik-host-drupal-prod
+            traefik.http.routers.drupal_https.tls.certresolver: *traefik-certresolver
         volumes:
             # No bind mounts in production.
             # Changes to anything other than data is not persisted.
@@ -503,7 +508,6 @@ services:
                     - activemq.islandora.dev
                     - blazegraph.islandora.dev
                     - fcrepo.islandora.dev
-                    - ide.islandora.dev
                     - islandora.dev # Drupal is at the root domain.
                     - solr.islandora.dev
         depends_on:


### PR DESCRIPTION
islandora.dev returns a 404 without this fix

and remove a lingering reference to the ide

[I have no specialized knowledge about this. This PR is the result of a few hours of systematic trial-and-error debugging.]