### PR TITLE
use native drush uri variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,7 @@ services:
             DRUPAL_DEFAULT_PROFILE: "minimal"
             DRUPAL_DEFAULT_SITE_URL: "${DOMAIN}"
             DRUPAL_DEFAULT_SOLR_CORE: "default"
-            DRUPAL_DRUSH_URI: "https://${DOMAIN}" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
+            DRUSH_OPTIONS_URI: "https://${DOMAIN}" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
         labels:
             <<: [*traefik-enable, *traefik-https-redirect-middleware, *traefik-drupal-labels]
             traefik.http.routers.drupal_http.rule: &traefik-host-drupal-prod Host(`${DOMAIN}`)
@@ -352,7 +352,7 @@ services:
             DRUPAL_DEFAULT_CANTALOUPE_URL: "https://${DOMAIN}/cantaloupe/iiif/2"
             DRUPAL_DEFAULT_FCREPO_URL: "https://fcrepo.${DOMAIN}/fcrepo/rest/"
             DRUPAL_DEFAULT_SITE_URL: "${DOMAIN}"
-            DRUPAL_DRUSH_URI: "https://${DOMAIN}"
+            DRUSH_OPTIONS_URI: "https://${DOMAIN}"
             NGINX_REAL_IP_RECURSIVE: ${REVERSE_PROXY}
             NGINX_SET_REAL_IP_FROM: ${FRONTEND_IP_1}
             NGINX_SET_REAL_IP_FROM2: ${FRONTEND_IP_2}

--- a/drupal/rootfs/etc/s6-overlay/scripts/install.sh
+++ b/drupal/rootfs/etc/s6-overlay/scripts/install.sh
@@ -12,15 +12,15 @@ function configure {
     # the cache before rebuilding it for some dumb reason, preventing
     # Drush from being able to clear it.
     local params=$(/var/www/drupal/web/core/scripts/rebuild_token_calculator.sh 2>/dev/null)
-    curl -L "${DRUPAL_DRUSH_URI}/core/rebuild.php?${params}"
+    curl -L "${DRUSH_OPTIONS_URI}/core/rebuild.php?${params}"
     # Starter site post install steps.
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" user:role:add fedoraadmin admin
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" pm:uninstall pgsql sqlite
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" migrate:import --userid=1 --tag=islandora
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cron || true
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" search-api:index || true
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cache:rebuild
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" user:role:add fedoraadmin admin
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" pm:uninstall pgsql sqlite
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" migrate:import --userid=1 --tag=islandora
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cron || true
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" search-api:index || true
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cache:rebuild
 }
 
 function install {


### PR DESCRIPTION
As [noted in Slack](https://islandora.slack.com/archives/CM6F4C4VA/p1751663503305519), it would be helpful to use an environment variable name that Drush can actually use for the URI.