### PR TITLE
Add reusable configuration to mergepdf service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,7 @@ services:
       - mariadb-data:/var/lib/mysql:rw
 
   mergepdf:
+    <<: *common
     image: islandora/mergepdf:${ISLANDORA_TAG}
     secrets:
       - source: CERT_PUBLIC_KEY


### PR DESCRIPTION
x-common configuration was missing for mergepdf service in docker compose file.