### PR TITLE
Onboarding improvements

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,6 +59,7 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'wsl-bash {0}' || 'bash' }}
       run: |
         make overwrite-starter-site init up \
+          ISLE_SITE_TEMPLATE_NONINTERACTIVE=true \
           ISLANDORA_TAG=${{ inputs.buildkit-tag }} \
           STARTER_SITE_BRANCH=${{ inputs.starter-site-ref }} \
           STARTER_SITE_OWNER=${{ inputs.starter-site-owner }} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,9 +259,6 @@ services:
 
   solr:
     <<: *common
-    depends_on:
-      drupal:
-        condition: service_healthy
     image: islandora/solr:${ISLANDORA_TAG}
     volumes:
       - solr-data:/data:rw
@@ -330,4 +327,3 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z
       - ./conf/traefik:/etc/traefik/dynamic:ro
       - acme-data:/acme:rw
-

--- a/sample.env
+++ b/sample.env
@@ -30,7 +30,7 @@ REPOSITORY=islandora.io
 TAG=local
 
 # https://github.com/Islandora-Devops/isle-buildkit tag to use
-ISLANDORA_TAG=6.2.9
+ISLANDORA_TAG=6.3.4
 
 DOMAIN=islandora.traefik.me
 
@@ -48,7 +48,7 @@ FRONTEND_IP_2=172.0.0.0/8
 FRONTEND_IP_3=192.168.0.0/16
 
 # Set to true if using the containers for development, runs start up scripts to remap `uid` of users inside of the container
-DEVELOPMENT_ENVIRONMENT=true
+DEVELOPMENT_ENVIRONMENT="true"
 
 # http or https
 URI_SCHEME="http"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -54,9 +54,6 @@ if $need_init; then
     echo_e "${YELLOW}Running in non-interactive mode, using defaults from .env${RESET}"
   fi
 
-  # Extend healthcheck for fresh install
-  update_env DRUPAL_HEALTHCHECK_RETRIES 10
-  update_env DRUPAL_HEALTHCHECK_START_PERIOD 1m
 fi
 
 if is_dev_mode && is_docker_rootless; then

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -2,24 +2,59 @@
 
 set -eou pipefail
 
-extend_healthcheck=false
+need_init=false
 if [ ! -f .env ]; then
   cp sample.env .env
-  extend_healthcheck=true
-fi
-
-if [ -n "${ISLANDORA_TAG:-}" ]; then
-  sed -i.bak "s|^ISLANDORA_TAG=.*|ISLANDORA_TAG=\"${ISLANDORA_TAG}\"|" .env
-  rm -f .env.bak
+  need_init=true
 fi
 
 # shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/profile.sh"
 
-if $extend_healthcheck; then
-  # we've detected an initial install
-  # so extend the default start period for drupal's healthcheck to 1m
-  # so it has time to come online before docker compose marks it unhealthy
+if [ -n "${ISLANDORA_TAG:-}" ]; then
+  update_env ISLANDORA_TAG "\"${ISLANDORA_TAG}\""
+fi
+
+if ! check_volumes_exist "$COMPOSE_PROJECT_NAME"; then
+  need_init=true
+fi
+
+if $need_init; then
+  if ! is_noninteractive; then
+    echo ""
+    echo_e "${BLUE}=== ISLE Site Configuration ===${RESET}"
+    echo "Configure your site settings (press Enter to accept defaults):"
+    echo ""
+
+    NEW_PROJECT_NAME=$(prompt_with_default "Compose project name" "$COMPOSE_PROJECT_NAME")
+    NEW_DOMAIN=$(prompt_with_default "Site domain" "$DOMAIN")
+
+    if [ "$NEW_PROJECT_NAME" != "$COMPOSE_PROJECT_NAME" ]; then
+      if [[ ! "$NEW_PROJECT_NAME" =~ ^[a-z0-9][a-z0-9_-]{0,63}$ ]]; then
+        echo "Invalid project name. Must be alphanumeric, hyphens, and underscores only (max 64 chars)."
+        exit 1
+      fi
+      update_env "COMPOSE_PROJECT_NAME" "$NEW_PROJECT_NAME"
+    fi
+
+    if [ "$NEW_DOMAIN" != "$DOMAIN" ]; then
+      IP=$(get_dns_ip "$NEW_DOMAIN")
+      if [ -z "$IP" ]; then
+        echo "Invalid domain name. Was unable to resolve the domain to an IP address."
+        exit 1
+      fi
+      update_env "DOMAIN" "$NEW_DOMAIN"
+    fi
+
+    echo ""
+    echo_e "${GREEN}Configuration saved to .env${RESET}"
+    export_env
+
+  else
+    echo_e "${YELLOW}Running in non-interactive mode, using defaults from .env${RESET}"
+  fi
+
+  # Extend healthcheck for fresh install
   update_env DRUPAL_HEALTHCHECK_RETRIES 10
   update_env DRUPAL_HEALTHCHECK_START_PERIOD 1m
 fi

--- a/scripts/sequelace.sh
+++ b/scripts/sequelace.sh
@@ -14,9 +14,17 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${SCRIPT_DIR}/profile.sh"
 
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-OVERRIDE_FILE="$PROJECT_ROOT/docker-compose.override.yml"
 
-if [ ! -f "$OVERRIDE_FILE" ]; then
+# Support both .yml and .yaml extensions
+if [ -f "$PROJECT_ROOT/docker-compose.override.yml" ]; then
+    OVERRIDE_FILE="$PROJECT_ROOT/docker-compose.override.yml"
+elif [ -f "$PROJECT_ROOT/docker-compose.override.yaml" ]; then
+    OVERRIDE_FILE="$PROJECT_ROOT/docker-compose.override.yaml"
+else
+    OVERRIDE_FILE=""
+fi
+
+if [ -z "$OVERRIDE_FILE" ]; then
     echo "${RED}Error: docker-compose.override.yml does not exist.${RESET}" >&2
     echo "" >&2
     echo "To enable mariadb port mapping, run:" >&2

--- a/scripts/traefik-http.sh
+++ b/scripts/traefik-http.sh
@@ -7,9 +7,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/profile.sh"
 
 echo "${BLUE}Switching to HTTP mode...${RESET}"
 
-sed -i.bak 's/^ENABLE_HTTPS=.*/ENABLE_HTTPS="false"/' .env && rm -f .env.bak
-sed -i.bak 's/^URI_SCHEME=.*/URI_SCHEME="http"/' .env && rm -f .env.bak
-sed -i.bak 's/^ENABLE_ACME=.*/ENABLE_ACME="false"/' .env && rm -f .env.bak
+update_env ENABLE_HTTPS "false"
+update_env URI_SCHEME "http"
+update_env ENABLE_ACME "false"
 
 set_https "false"
 set_letsencrypt_config "false"

--- a/scripts/traefik-https-letsencrypt.sh
+++ b/scripts/traefik-https-letsencrypt.sh
@@ -5,6 +5,63 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/profile.sh"
 
+# Get the public IP of the current host
+get_public_ip() {
+  curl -s --max-time 5 https://ifconfig.me 2>/dev/null || \
+  curl -s --max-time 5 https://api.ipify.org 2>/dev/null || \
+  curl -s --max-time 5 https://icanhazip.com 2>/dev/null || \
+  echo ""
+}
+
+# Verify DNS records required for Let's Encrypt
+verify_dns() {
+  local domain="$1"
+  local errors=0
+
+  echo_e "${BLUE}Verifying DNS records for Let's Encrypt...${RESET}"
+
+  local public_ip
+  public_ip=$(get_public_ip)
+  if [ -z "$public_ip" ]; then
+    echo_e "${YELLOW}Warning: Could not determine public IP. Skipping DNS verification.${RESET}"
+    return 0
+  fi
+  echo "  Public IP: $public_ip"
+
+  # Required domains: main domain and fcrepo subdomain
+  local required_domains=("$domain" "fcrepo.$domain")
+
+  for host in "${required_domains[@]}"; do
+    local resolved_ip
+    resolved_ip=$(get_dns_ip "$host")
+
+    if [ -z "$resolved_ip" ]; then
+      echo_e "  ${RED}✗ $host - does not resolve${RESET}"
+      errors=$((errors + 1))
+    elif [ "$resolved_ip" != "$public_ip" ]; then
+      echo_e "  ${RED}✗ $host - resolves to $resolved_ip (expected $public_ip)${RESET}"
+      errors=$((errors + 1))
+    else
+      echo_e "  ${GREEN}✓ $host - resolves to $resolved_ip${RESET}"
+    fi
+  done
+
+  if [ $errors -gt 0 ]; then
+    echo ""
+    echo_e "${RED}DNS verification failed.${RESET}"
+    echo "Ensure the following DNS records point to $public_ip:"
+    for host in "${required_domains[@]}"; do
+      echo "  - $host"
+    done
+    echo ""
+    echo "Let's Encrypt requires valid DNS records to issue certificates."
+    return 1
+  fi
+
+  echo_e "${GREEN}DNS verification passed.${RESET}"
+  return 0
+}
+
 if is_wsl; then
   echo "${RED}Error: letsencrypt is not supported using WSL.${RESET}"
   exit 1
@@ -25,23 +82,35 @@ NEW_DOMAIN=${NEW_DOMAIN:-$CURRENT_DOMAIN}
 read -r -p "Enter email for Let's Encrypt notifications (current: ${CURRENT_EMAIL}): " NEW_EMAIL
 NEW_EMAIL=${NEW_EMAIL:-$CURRENT_EMAIL}
 
+# Verify DNS before proceeding
+echo
+if ! verify_dns "$NEW_DOMAIN"; then
+  exit 1
+fi
+
 echo
 echo "Updating .env with:"
 echo "  ${GREEN}URI_SCHEME=https"
 echo "  DOMAIN=${NEW_DOMAIN}"
 echo "  ACME_EMAIL=${NEW_EMAIL}"
-echo "  URI_SCHEME=http"
 echo "  DEVELOPMENT_ENVIRONMENT=false${RESET}"
 echo
 
-# Update .env file
-sed -i.bak 's|^DEVELOPMENT_ENVIRONMENT=.*|DEVELOPMENT_ENVIRONMENT="false"|' .env && rm -f .env.bak
-sed -i.bak "s|^DOMAIN=.*|DOMAIN=${NEW_DOMAIN}|" .env && rm -f .env.bak
-sed -i.bak "s|^ACME_EMAIL=.*|ACME_EMAIL=${NEW_EMAIL}|" .env && rm -f .env.bak
+update_env DEVELOPMENT_ENVIRONMENT "false"
+update_env DOMAIN "$NEW_DOMAIN"
+update_env ACME_EMAIL "$NEW_EMAIL"
 
 set_https "true"
 set_letsencrypt_config "true"
 
-echo "Site will be available at: ${GREEN}${URI_SCHEME}://${DOMAIN}${RESET}"
-echo "Run this for the changes to take effect:"
-echo "${BLUE}make down-traefik up${RESET}"
+echo "Site will be available at: ${GREEN}${URI_SCHEME}://${NEW_DOMAIN}${RESET}"
+echo "Run this for the changes to take effect (will result in ~2m site down time):"
+echo "${BLUE}make down-traefik up"
+
+# we first recycle traefik so it can come up with the new ACME config
+# we should wait until traefik gets its new certs
+# there isn't an easy way to detect that
+# so we just wait 60s and then recycle the entire stack
+# to ensure all containers have the proper CA
+echo "sleep 60 && make down up${RESET}"
+

--- a/scripts/traefik-https-mkcert.sh
+++ b/scripts/traefik-https-mkcert.sh
@@ -13,8 +13,7 @@ fi
 echo "${BLUE}Switching to HTTPS mode with mkcert...${RESET}"
 
 # Update .env file
-sed -i.bak 's/^URI_SCHEME=.*/URI_SCHEME="https"/' .env && rm -f .env.bak
-sed -i.bak 's/^TLS_PROVIDER=.*/TLS_PROVIDER="self-managed"/' .env && rm -f .env.bak
+update_env URI_SCHEME "https"
 set_https "true"
 set_letsencrypt_config "false"
 

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -2,19 +2,11 @@
 
 set -eou pipefail
 
-if [ -f .env ]; then
-  # Export variables so docker-compose and this script can see them
-  # shellcheck disable=SC1091
-  source .env
-else
-  echo "Error: .env file not found." >&2
-  ./scripts/init.sh
-  # shellcheck disable=SC1091
-  source .env
-fi
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/init.sh"
 
 # shellcheck disable=SC1091
-source "$(dirname "${BASH_SOURCE[0]}")/profile.sh"
+source .env
 
 HTTP_PORT=80
 HTTPS_PORT=443

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -59,13 +59,6 @@ echo "---------------------------------------------------"
 echo "🚀 Site available at: $URL"
 echo "---------------------------------------------------"
 
-# if we extended the healthcheck during init
-# set the values back
-if ${extend_healthcheck:-false}; then
-  update_env DRUPAL_HEALTHCHECK_RETRIES 3
-  update_env DRUPAL_HEALTHCHECK_START_PERIOD 0s
-fi
-
 # don't open the URL if we're in GHA
 if [ "${GITHUB_ACTIONS:-}" != "" ]; then
   exit 0


### PR DESCRIPTION
When first installing a site, unless `ISLE_SITE_TEMPLATE_NONINTERACTIVE=true` ask a few questions about some consequential settings. Namely: `COMPOSE_PROJECT_NAME` and `DOMAIN`

Also, in addition to checking if `.env` exists, ensure the docker volumes the project creates exist. If either conditional is false, assume we're installing Drupal for the first time.

And cleanup some bash to use the `update_env` helper