### PR TITLE
only configure drupal's fedora flysystem driver if the service has a fcrepo URL

### DIFF
--- a/drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt
+++ b/drupal/rootfs/var/www/drupal/assets/patches/default_settings.txt
@@ -69,9 +69,11 @@ $databases['default']['default'] = [
   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
 ];
 
-// Flysystem
-$settings['flysystem']['fedora']['driver'] = 'fedora';
-$settings['flysystem']['fedora']['config']['root'] = file_get_contents($path . 'DRUPAL_DEFAULT_FCREPO_URL');
+// only config fedora flysystem driver if the drupal service set a fcrepo URL
+if (file_exists($path . 'DRUPAL_DEFAULT_FCREPO_URL')) {
+  $settings['flysystem']['fedora']['driver'] = 'fedora';
+  $settings['flysystem']['fedora']['config']['root'] = file_get_contents($path . 'DRUPAL_DEFAULT_FCREPO_URL');
+}
 
 // Change the php_storage settings in your setting.php. It is recommend that
 // this directory be outside out of the docroot.


### PR DESCRIPTION
Hotfix for https://github.com/Islandora-Devops/isle-site-template/pull/132

When we disable fcrepo, we're disabling `DRUPAL_DEFAULT_FCREPO_URL` so in settings.php do not configure the flysystem fedora plugin if that value isn't set