### PR TITLE
Login automatically on `make up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ configurations this template is set up for the following:
     ```
     This command prepares your host machine, creates the `.env` file from `sample.env` if it doesn't exist, generates necessary secrets and certificates, and builds the Docker images.
 
-    Then brings up the ISLE stack using smart port allocation. The URL for your site will be displayed in the output and automatically opened in your browser if possible.
+    Then brings up the ISLE stack using smart port allocation. The URL for your site will be displayed in the output, and in an interactive local terminal `make up` will open your browser with a Drupal one-time login link for `uid=1`.
 
     Default URL: [http://islandora.traefik.me](http://islandora.traefik.me) (maps to 127.0.0.1)
 

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -70,7 +70,6 @@ fi
 
 echo "---------------------------------------------------"
 echo "🚀 Site available at: $URL"
-echo "---------------------------------------------------"
 
 # if we extended the healthcheck during init
 # set the values back
@@ -78,6 +77,13 @@ if ${extend_healthcheck:-false}; then
   update_env DRUPAL_HEALTHCHECK_RETRIES 3
   update_env DRUPAL_HEALTHCHECK_START_PERIOD 0s
 fi
+
+OPEN_URL="$URL"
+if ULI_URL=$(docker compose exec drupal drush uli 2>/dev/null); then
+    OPEN_URL="$ULI_URL"
+    echo "🔐 Login to your site at: $ULI_URL"
+fi
+echo "---------------------------------------------------"
 
 # don't open the URL if we're in GHA
 if [ "${GITHUB_ACTIONS:-}" != "" ]; then
@@ -87,20 +93,6 @@ fi
 # don't open the URL if we're in an SSH session
 if [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_CLIENT:-}" ] || [ -n "${SSH_TTY:-}" ]; then
   exit 0
-fi
-
-# only request a one-time login link in interactive terminals
-if [ ! -t 1 ]; then
-  exit 0
-fi
-
-OPEN_URL="$URL"
-if ULI_URL=$(docker compose exec -T drupal drush uli 2>/dev/null); then
-    OPEN_URL="$ULI_URL"
-    echo "Admin login link: $ULI_URL"
-else
-    echo "Unable to generate an admin login link automatically."
-    echo "Run: docker compose exec drupal drush uli"
 fi
 
 # Open in Browser (Cross-Platform)

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -89,14 +89,28 @@ if [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_CLIENT:-}" ] || [ -n "${SSH_TTY:-
   exit 0
 fi
 
-# 6. Open in Browser (Cross-Platform)
+# only request a one-time login link in interactive terminals
+if [ ! -t 1 ]; then
+  exit 0
+fi
+
+OPEN_URL="$URL"
+if ULI_URL=$(docker compose exec -T drupal drush uli 2>/dev/null); then
+    OPEN_URL="$ULI_URL"
+    echo "Admin login link: $ULI_URL"
+else
+    echo "Unable to generate an admin login link automatically."
+    echo "Run: docker compose exec drupal drush uli"
+fi
+
+# Open in Browser (Cross-Platform)
 case "$(uname -s)" in
-    Darwin*)    open "$URL" ;;
+    Darwin*)    open "$OPEN_URL" ;;
     Linux*)     if grep -qi microsoft /proc/version; then
-                    powershell.exe Start-Process "$URL" # WSL
+                    powershell.exe Start-Process "$OPEN_URL" # WSL
                 else
-                    xdg-open "$URL" # Standard Linux
+                    xdg-open "$OPEN_URL" # Standard Linux
                 fi ;;
-    CYGWIN*|MINGW*|MSYS*) start "$URL" ;; # Windows Native
-    *)          echo "You can open $URL in your browser." ;;
+    CYGWIN*|MINGW*|MSYS*) start "$OPEN_URL" ;; # Windows Native
+    *)          echo "You can open $OPEN_URL in your browser." ;;
 esac


### PR DESCRIPTION
instead of dropping people into an anonymous session on the drupal site they just installed, we should auto-open a `drush uli` session to give them a step in the right direction