### PR TITLE
Move dev to islandora.io and add certificate secrets to alpaca service

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,13 +49,13 @@ jobs:
 
       - name: Explicit check (TLS)
         if: startsWith(matrix.os, 'ubuntu')
-        run: curl -vsf -o /dev/null https://islandora.traefik.me
+        run: curl -vsf -o /dev/null https://islandora.io
 
       - name: Switch back to HTTP
         run: make traefik-http down-traefik up ping
 
       - name: Explicit check (http)
-        run: curl -vsf -o /dev/null http://islandora.traefik.me
+        run: curl -vsf -o /dev/null http://islandora.io
 
       - name: Collect logs for each service
         if: ${{ failure() }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ configurations this template is set up for the following:
 
     Then brings up the ISLE stack using smart port allocation. The URL for your site will be displayed in the output and automatically opened in your browser if possible.
 
-    Default URL: [http://islandora.traefik.me](http://islandora.traefik.me) (maps to 127.0.0.1)
+    Default URL: [http://islandora.io](http://islandora.io) (maps to 127.0.0.1)
 
     *Note: The first start will take several minutes as Drupal installs.*
 
@@ -110,7 +110,7 @@ Edit this file to customize your setup.
 Key variables:
 - `COMPOSE_PROJECT_NAME`: Unique name for your project.
 - `ISLANDORA_TAG`: Version of [Isle Buildkit](https://github.com/Islandora-Devops/isle-buildkit) images.
-- `DOMAIN`: The domain name for your site (default: `islandora.traefik.me`).
+- `DOMAIN`: The domain name for your site (default: `islandora.io`).
 - `REPOSITORY`: Docker registry for pushing/pulling images.
 
 ### HTTPS & Certificates
@@ -182,20 +182,20 @@ If you have these default values in your `.env` file
 
 ```
 URI_SCHEME=http
-DOMAIN=islandora.traefik.me
+DOMAIN=islandora.io
 DEVELOPMENT_ENVIRONMENT=true
 ```
 you can access all the services at the following URLs.
 
 | Service    | URL                                       |
 | :--------- | :---------------------------------------- |
-| Drupal     | http://islandora.traefik.me                     |
-| ActiveMQ   | http://activemq.islandora.traefik.me            |
-| Blazegraph | http://blazegraph.islandora.traefik.me/bigdata/ |
-| Cantaloupe | http://islandora.traefik.me/cantaloupe          |
-| Fedora     | http://fcrepo.islandora.traefik.me/fcrepo/rest/ |
-| Solr       | http://solr.islandora.traefik.me                |
-| Traefik    | http://traefik.islandora.traefik.me             |
+| Drupal     | http://islandora.io                     |
+| ActiveMQ   | http://activemq.islandora.io            |
+| Blazegraph | http://blazegraph.islandora.io/bigdata/ |
+| Cantaloupe | http://islandora.io/cantaloupe          |
+| Fedora     | http://fcrepo.islandora.io/fcrepo/rest/ |
+| Solr       | http://solr.islandora.io                |
+| Traefik    | http://traefik.islandora.io             |
 
 > [!IMPORTANT]
 > DEVELOPMENT_ENVIRONMENT should never be set to `true` for sites available on the public internet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
     image: islandora/alpaca:${ISLANDORA_TAG}
     secrets:
       - source: ALPACA_JMS_PASSWORD
+      - source: CERT_PUBLIC_KEY
+      - source: CERT_AUTHORITY
 
   blazegraph:
     <<: *common

--- a/sample.env
+++ b/sample.env
@@ -32,7 +32,7 @@ TAG=local
 # https://github.com/Islandora-Devops/isle-buildkit tag to use
 ISLANDORA_TAG=6.3.16
 
-DOMAIN=islandora.traefik.me
+DOMAIN=islandora.io
 
 # Set to "on" if your ISLE docker deployment is behind a reverse proxy
 REVERSE_PROXY=off

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -31,8 +31,6 @@ mkcert -cert-file certs/cert.pem -key-file certs/privkey.pem \
   "islandora.io" \
   "*.islandora.info" \
   "islandora.info" \
-  "*.islandora.io" \
-  "islandora.io" \
   "localhost" \
   "127.0.0.1" \
   "::1"

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -31,8 +31,8 @@ mkcert -cert-file certs/cert.pem -key-file certs/privkey.pem \
   "islandora.io" \
   "*.islandora.info" \
   "islandora.info" \
-  "*.islandora.traefik.me" \
-  "islandora.traefik.me" \
+  "*.islandora.io" \
+  "islandora.io" \
   "localhost" \
   "127.0.0.1" \
   "::1"

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -123,7 +123,7 @@ if [ -f .env ]; then
     fi
 
     ACME_EMAIL=$(grep '^ACME_EMAIL=' .env | cut -d'=' -f2 | tr -d '"' || echo "postmaster@example.com")
-    DOMAIN=$(grep '^DOMAIN=' .env | cut -d'=' -f2 | tr -d '"' || echo "islandora.traefik.me")
+    DOMAIN=$(grep '^DOMAIN=' .env | cut -d'=' -f2 | tr -d '"' || echo "islandora.io")
     ISLANDORA_TAG=$(grep '^ISLANDORA_TAG=' .env | cut -d'=' -f2 | tr -d '"' || echo "main")
     TAG=$(grep '^TAG=' .env | cut -d'=' -f2 | tr -d '"' || echo "local")
     REPOSITORY=$(grep '^REPOSITORY=' .env | cut -d'=' -f2 | tr -d '"' || echo "islandora.io")


### PR DESCRIPTION
Related slack conversations:

- alpaca config causing issues with custom TLS certs: https://islandora.slack.com/archives/C019U12D44Q/p1778590617085369
- local dev DNS issue with `islandora.traefik.me` https://islandora.slack.com/archives/CM6F4C4VA/p1778330503986489