### PR TITLE
Do not cause uninstalling pgsql/sqlite to fail install

### DIFF
--- a/drupal/rootfs/etc/s6-overlay/scripts/install.sh
+++ b/drupal/rootfs/etc/s6-overlay/scripts/install.sh
@@ -17,7 +17,7 @@ function configure {
     if [ -n "${DRUPAL_DEFAULT_FCREPO_URL:-}" ]; then
       drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" user:role:add fedoraadmin admin
     fi
-    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" pm:uninstall pgsql sqlite
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" pm:uninstall pgsql sqlite || true
     drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" migrate:import --userid=1 --tag=islandora
     drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cron || true
     drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" search-api:index || true


### PR DESCRIPTION
When using ISLE Site template to develop on the starter site, and doing `drush cex` on the site after site building, this causes a rebuild to fail. This results in a poor developer experience when iterating on starter site using site template.

We probably should consider just not shipping starter site with these two modules enabled, but for now just don't break site install if `config/sync/core.extension.yml` doesn't have these two modules installed.