### PR TITLE
Bump buildkit to 7.x and pin blazegraph to 6.4.3

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,8 +2,8 @@ name: "Setup ISLE Composite"
 description: "Sets up the ISLE environment"
 inputs:
   buildkit-tag:
-    description: "islandora-devops/isle-buildkit docker tag to pull"
-    default: "main"
+    description: "islandora-devops/isle-buildkit docker tag to pull; when empty, use ISLANDORA_TAG from sample.env"
+    default: ""
   starter-site-owner:
     description: "islandora-starter-site github owner"
     default: "Islandora-Devops"
@@ -23,6 +23,11 @@ runs:
 
     - name: Validate Inputs
       shell: ${{ runner.os == 'Windows' && 'wsl-bash {0}' || 'bash' }}
+      env:
+        BUILDKIT_TAG: ${{ inputs.buildkit-tag }}
+        STARTER_SITE_OWNER: ${{ inputs.starter-site-owner }}
+        STARTER_SITE_REF: ${{ inputs.starter-site-ref }}
+        WSLENV: BUILDKIT_TAG:STARTER_SITE_OWNER:STARTER_SITE_REF
       run: |
         REGEX_DOCKER="^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$"
         REGEX_GITHUB_OWNER="^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$"
@@ -37,9 +42,11 @@ runs:
           fi
         }
 
-        validate "buildkit-tag" "${{ inputs.buildkit-tag }}" "$REGEX_DOCKER"
-        validate "starter-site-owner" "${{ inputs.starter-site-owner }}" "$REGEX_GITHUB_OWNER"
-        validate "starter-site-ref" "${{ inputs.starter-site-ref }}" "$REGEX_GIT_REF"
+        if [[ -n ${BUILDKIT_TAG:-} ]]; then
+          validate "buildkit-tag" "$BUILDKIT_TAG" "$REGEX_DOCKER"
+        fi
+        validate "starter-site-owner" "$STARTER_SITE_OWNER" "$REGEX_GITHUB_OWNER"
+        validate "starter-site-ref" "$STARTER_SITE_REF" "$REGEX_GIT_REF"
 
     - name: setup git identity
       shell: ${{ runner.os == 'Windows' && 'wsl-bash {0}' || 'bash' }}
@@ -57,13 +64,23 @@ runs:
 
     - name: Start islandora-starter-site
       shell: ${{ runner.os == 'Windows' && 'wsl-bash {0}' || 'bash' }}
+      env:
+        BUILDKIT_TAG: ${{ inputs.buildkit-tag }}
+        STARTER_SITE_OWNER: ${{ inputs.starter-site-owner }}
+        STARTER_SITE_REF: ${{ inputs.starter-site-ref }}
+        WSLENV: BUILDKIT_TAG:STARTER_SITE_OWNER:STARTER_SITE_REF
       run: |
-        make overwrite-starter-site init up \
-          ISLANDORA_TAG=${{ inputs.buildkit-tag }} \
-          STARTER_SITE_BRANCH=${{ inputs.starter-site-ref }} \
-          STARTER_SITE_OWNER=${{ inputs.starter-site-owner }} \
-          GITHUB_ACTIONS="true" \
-          TERM=xterm-256color
+        make_args=(
+          overwrite-starter-site init up
+          "STARTER_SITE_BRANCH=$STARTER_SITE_REF"
+          "STARTER_SITE_OWNER=$STARTER_SITE_OWNER"
+          'GITHUB_ACTIONS=true'
+          'TERM=xterm-256color'
+        )
+        if [[ -n ${BUILDKIT_TAG:-} ]]; then
+          make_args+=("ISLANDORA_TAG=$BUILDKIT_TAG")
+        fi
+        make "${make_args[@]}"
 
     - name: make sure traefik is serving traffic
       shell: ${{ runner.os == 'Windows' && 'wsl-bash {0}' || 'bash' }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup ISLE
         uses: ./.github/actions/setup
         with:
-          buildkit-tag: "${{ github.event.inputs.buildkit-tag || 'main' }}"
+          buildkit-tag: "${{ github.event.inputs.buildkit-tag }}"
           starter-site-owner: "${{ github.event.inputs.starter-site-owner || 'islandora-devops' }}"
           starter-site-ref: "${{ github.event.inputs.starter-site-ref || 'heads/main' }}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       activemq:
         condition: service_healthy
     image: islandora/alpaca:${ISLANDORA_TAG}
+    environment:
+      ALPACA_TRIPLESTORE_INDEXER_ENABLED: "true"
     secrets:
       - source: ALPACA_JMS_PASSWORD
       - source: CERT_PUBLIC_KEY
@@ -79,7 +81,7 @@ services:
 
   blazegraph:
     <<: *common
-    image: islandora/blazegraph:${ISLANDORA_TAG}
+    image: islandora/blazegraph:6.4.3@sha256:015e308ae0a296cdb87c83c10da976ed970d2bfa971290aa1147593df8cf445d
     volumes:
       - blazegraph-data:/data:rw
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       FCREPO_ALLOW_EXTERNAL_DEFAULT: http://default/
       FCREPO_ALLOW_EXTERNAL_DRUPAL: ${URI_SCHEME}://${DOMAIN}/
       FCREPO_PERSISTENCE_TYPE: mysql
-    image: islandora/fcrepo6:${ISLANDORA_TAG}
+    image: islandora/fcrepo:${ISLANDORA_TAG}
     secrets:
       - source: DB_ROOT_PASSWORD
       - source: FCREPO_DB_PASSWORD

--- a/sample.env
+++ b/sample.env
@@ -30,7 +30,7 @@ REPOSITORY=islandora.io
 TAG=local
 
 # https://github.com/Islandora-Devops/isle-buildkit tag to use
-ISLANDORA_TAG=alpine-3-24
+ISLANDORA_TAG=7.0.0
 
 DOMAIN=islandora.io
 

--- a/sample.env
+++ b/sample.env
@@ -30,7 +30,7 @@ REPOSITORY=islandora.io
 TAG=local
 
 # https://github.com/Islandora-Devops/isle-buildkit tag to use
-ISLANDORA_TAG=7.0.0
+ISLANDORA_TAG=7.0.7
 
 DOMAIN=islandora.io
 

--- a/sample.env
+++ b/sample.env
@@ -30,7 +30,7 @@ REPOSITORY=islandora.io
 TAG=local
 
 # https://github.com/Islandora-Devops/isle-buildkit tag to use
-ISLANDORA_TAG=6.3.16
+ISLANDORA_TAG=alpine-3-24
 
 DOMAIN=islandora.io
 


### PR DESCRIPTION
Since https://github.com/Islandora-Devops/isle-buildkit/pull/577 has buildkit no longer build blazegraph, pin the blazegraph image to the last tag we'll push. Though keep blazegraph enabled for now pending further community discussion of the direction for a graph db.

Also change the fcrepo image to its new name.

And fix CI so we can test buildkit tags by chaning the value in `sample.env`

## Testing

```
git clone https://github.com/islandora-devops/isle-site-template
cd isle-site-template
gh pr checkout 159
make demo-objects
```

## Merge order

https://github.com/Islandora-Devops/isle-buildkit/pull/577 should merge first, then we can update `sample.env` to use `7.0.0` and merge this PR